### PR TITLE
Try internal dns redirects

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -107,8 +107,8 @@ kind: Ingress
 metadata:
   name: team-external-auth
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "http://$host/api/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "http://$host/oauth2/callback?redirect_to=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/auth-url: "http://team-web-internal.default.svc.cluster.local:3000/api/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "http://team-web-internal.default.svc.cluster.local:3000/oauth2/callback?redirect_to=$escaped_request_uri"
 spec:
   rules:
     - host: team-staging.artsy.net


### PR DESCRIPTION
Okay, so still not getting the service to resolve. I think the external auth is the issue here, so instead of relying on `$host` I'm switching over to the custom internal domains I've seen referenced just to see what happens. 

![hold on to your butts](https://media.giphy.com/media/2Z3lgZOhISkYU/giphy.gif)