### PR TITLE
Adds a list of direct reports on the member profile

### DIFF
--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -2,7 +2,7 @@ import csv from "csvtojson";
 import pLimit from "p-limit";
 import { imageCache } from "utils/models";
 import { hash } from "utils";
-import { capitalize, isEmpty, omit, union, memoize } from "lodash-es";
+import { capitalize, isEmpty, omit, union, memoize, uniqBy } from "lodash-es";
 import { Member } from "../pages/index";
 import { resizeImage } from "./image";
 import { log } from "utils/logger";
@@ -74,9 +74,13 @@ export const getMembers = memoize(async () => {
           member.manager = omit(manager, "manager");
         }
       }
-      const reports = parsed
-        .filter((m) => m.reports_to === member.name)
-        .map((report) => omit(report, ["manager", "reports"]));
+      const reports = uniqBy(
+        parsed
+          .filter((m) => m.reports_to === member.name)
+          .map((report) => omit(report, ["manager", "reports"])),
+        "name"
+      );
+
       if (reports.length > 0) {
         member.reports = reports;
       }

--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -5,6 +5,7 @@ import { hash } from "utils";
 import { capitalize, isEmpty, omit, union, memoize } from "lodash-es";
 import { Member } from "../pages/index";
 import { resizeImage } from "./image";
+import { log } from "utils/logger";
 
 const limit = pLimit(10);
 
@@ -22,8 +23,8 @@ const getResizedImageUrl = async (
       if (!resizedImageUrl) {
         return;
       }
-      console.log(`resized ${imageUrl} to ${size}`);
-      console.log(resizedImageUrl);
+      log.info(`resized ${imageUrl} to ${size}`);
+      log.info(resizedImageUrl);
       await imageCache.set(cacheKey, resizedImageUrl);
       return resizedImageUrl;
     }
@@ -72,6 +73,12 @@ export const getMembers = memoize(async () => {
         if (!isEmpty(manager)) {
           member.manager = omit(manager, "manager");
         }
+      }
+      const reports = parsed
+        .filter((m) => m.reports_to === member.name)
+        .map((report) => omit(report, ["manager", "reports"]));
+      if (reports.length > 0) {
+        member.reports = reports;
       }
       return member;
     });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,6 +33,7 @@ export interface Member {
   preferred_pronouns?: string;
   profileImage?: string;
   manager?: Member;
+  reports?: Member[];
 }
 
 export interface ServerProps {

--- a/src/pages/member/[member].tsx
+++ b/src/pages/member/[member].tsx
@@ -14,7 +14,7 @@ import {
 import Error from "next/error";
 import { normalizeParam } from "utils";
 import { capitalize } from "lodash-es";
-import { useMemo, FC } from "react";
+import { FC, Fragment } from "react";
 import { H1 } from "components/Typography";
 import RouterLink from "next/link";
 import { Member as MemberType, ServerProps } from "../index";
@@ -51,7 +51,7 @@ interface MemberProps {
 
 const Member: FC<MemberProps> = (props) => {
   const { member } = props;
-  const { manager } = member;
+  const { manager, reports } = member;
 
   if (!member) {
     return <Error statusCode={404} />;
@@ -157,7 +157,7 @@ const Member: FC<MemberProps> = (props) => {
             {manager && (
               <Flex mb={0.5}>
                 <Serif size="4" weight="semibold" style={{ flex: 1 }}>
-                  Manager
+                  Manager:
                 </Serif>
                 <Box style={{ flex: 1 }}>
                   <RouterLink
@@ -165,10 +165,32 @@ const Member: FC<MemberProps> = (props) => {
                     as={`/member/${normalizeParam(manager.name)}`}
                     passHref
                   >
-                    <Link>
+                    <Link noUnderline>
                       <Serif size="4">{manager.name}</Serif>
                     </Link>
                   </RouterLink>
+                </Box>
+              </Flex>
+            )}
+            {reports && (
+              <Flex mb={0.5}>
+                <Serif size="4" weight="semibold" style={{ flex: 1 }}>
+                  Reports:
+                </Serif>
+                <Box style={{ flex: 1 }}>
+                  {reports.map((report) => (
+                    <Fragment key={`report-${normalizeParam(report.name)}`}>
+                      <RouterLink
+                        href={"/member/[member]"}
+                        as={`/member/${normalizeParam(report.name)}`}
+                        passHref
+                      >
+                        <Link noUnderline>
+                          <Serif size="4">{report.name}</Serif>
+                        </Link>
+                      </RouterLink>
+                    </Fragment>
+                  ))}
                 </Box>
               </Flex>
             )}


### PR DESCRIPTION
I'd gotten some feedback that folks were missing the ability to see a manager's direct reports. This update restores that functionality to the member page. 