### PR TITLE
Simplify gsheet by enabling deduplicating people

### DIFF
--- a/src/components/MemberDetails.tsx
+++ b/src/components/MemberDetails.tsx
@@ -12,11 +12,16 @@ interface MemberDetailsProps {
 }
 
 export function MemberDetails({ member }: MemberDetailsProps) {
-  const { manager, reports } = member;
-  const showOrg = !!member.org;
-  const showTeam = showOrg && member.team && !member.org?.includes(member.team);
-  const showSubteam =
-    showTeam && member.subteam && !member.team!.includes(member.subteam);
+  const { manager, reports, orgs, teams, subteams } = member;
+  const showOrgs = member.orgs.length > 0;
+  const showTeams =
+    showOrgs &&
+    teams.length > 0 &&
+    teams.filter((team) => !orgs.includes(team)).length > 0;
+  const showSubteams =
+    showTeams &&
+    subteams.length > 0 &&
+    subteams.filter((subteam) => !teams.includes(subteam)).length > 0;
 
   return (
     <Grid
@@ -51,58 +56,66 @@ export function MemberDetails({ member }: MemberDetailsProps) {
         )}
 
         {/* Show organization */}
-        {showOrg && (
+        {showOrgs && (
           <>
             <Serif size="4" weight="semibold">
               Organization:
             </Serif>
-
-            <RouterLink
-              href={"/org/[org]"}
-              as={`/org/${normalizeParam(member.org!)}`}
-              passHref
-            >
-              <Link noUnderline>
-                <Serif size="4">{member.org}</Serif>
-              </Link>
-            </RouterLink>
+            <span>
+              {orgs.map((org) => (
+                <Fragment key={`org-${normalizeParam(org)}`}>
+                  <RouterLink href={`/org/${normalizeParam(org)}`} passHref>
+                    <Link noUnderline>
+                      <Serif size="4">{org}</Serif>
+                    </Link>
+                  </RouterLink>
+                </Fragment>
+              ))}
+            </span>
           </>
         )}
 
         {/* Show team */}
-        {showTeam && (
+        {showTeams && (
           <>
             <Serif size="4" weight="semibold">
               Team:
             </Serif>
 
-            <RouterLink
-              href={"/team/[team]"}
-              as={`/team/${normalizeParam(member.team!)}`}
-              passHref
-            >
-              <Link noUnderline>
-                <Serif size="4">{member.team}</Serif>
-              </Link>
-            </RouterLink>
+            <span>
+              {teams.map((team) => (
+                <Fragment key={`team-${normalizeParam(team)}`}>
+                  <RouterLink href={`/team/${normalizeParam(team)}`} passHref>
+                    <Link noUnderline>
+                      <Serif size="4">{team}</Serif>
+                    </Link>
+                  </RouterLink>
+                </Fragment>
+              ))}
+            </span>
           </>
         )}
 
         {/* Show subteam */}
-        {showSubteam && (
+        {showSubteams && (
           <>
             <Serif size="4" weight="semibold">
               Subteam:
             </Serif>
-            <RouterLink
-              href={"/subteam/[subteam]"}
-              as={`/subteam/${normalizeParam(member.subteam!)}`}
-              passHref
-            >
-              <Link noUnderline>
-                <Serif size="4">{member.subteam}</Serif>
-              </Link>
-            </RouterLink>
+            <span>
+              {subteams.map((subteam) => (
+                <Fragment key={`subteam-${normalizeParam(subteam)}`}>
+                  <RouterLink
+                    href={`/subteam/${normalizeParam(subteam)}`}
+                    passHref
+                  >
+                    <Link noUnderline>
+                      <Serif size="4">{subteam}</Serif>
+                    </Link>
+                  </RouterLink>
+                </Fragment>
+              ))}
+            </span>
           </>
         )}
 

--- a/src/data/team.ts
+++ b/src/data/team.ts
@@ -43,17 +43,21 @@ export const getMembers = memoize(async () => {
     .then((res) => res.text())
     .then((csvContent) => csv().fromString(csvContent));
 
-  const seen = new Set();
   const promisedMembers = parsed
-    .filter((member) => {
-      if (member.name && !seen.has(member.name)) {
-        seen.add(member.name);
-        return true;
-      }
-      return false;
-    })
     .sort((a, b) => (a.name > b.name ? 1 : a.name < b.name ? -1 : 0)) // sort alphabetically
     .map(async (member) => {
+      member.orgs ??= member.org?.split(";") ?? [];
+      member.orgs = member.orgs
+        .map((org) => org.trim())
+        .filter((org) => org.length > 0);
+      member.teams ??= member.team?.split(";") ?? [];
+      member.teams = member.teams
+        .map((team) => team.trim())
+        .filter((team) => team.length > 0);
+      member.subteams ??= member.subteam?.split(";") ?? [];
+      member.subteams = member.subteams
+        .map((subteam) => subteam.trim())
+        .filter((subteam) => subteam.length > 0);
       if (member.preferred_pronouns) {
         member.preferred_pronouns = member.preferred_pronouns
           .split("/")

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,9 +11,15 @@ import { TeamMember } from "../components/TeamMember";
 export interface Member {
   name: string;
   title?: string;
+  /** @deprecated prefer `orgs` */
   org?: string;
+  orgs: string[];
+  /** @deprecated prefer `teams` */
   team?: string;
+  teams: string[];
+  /** @deprecated prefer `subteams` */
   subteam?: string;
+  subteams: string[];
   reports_to?: string;
   team_rank?: number;
   email?: string;
@@ -57,6 +63,8 @@ const normalizeSearchTerm = (content: string) => {
 const TeamNav: FC<ServerProps> = (props) => {
   const { title, data, NoResults = DefaultNoResults } = props;
   const searchParam = useSearchParam();
+
+  console.log("data", data);
 
   if (!data) {
     return <Error statusCode={500} />;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -64,8 +64,6 @@ const TeamNav: FC<ServerProps> = (props) => {
   const { title, data, NoResults = DefaultNoResults } = props;
   const searchParam = useSearchParam();
 
-  console.log("data", data);
-
   if (!data) {
     return <Error statusCode={500} />;
   }

--- a/src/pages/org/[org].tsx
+++ b/src/pages/org/[org].tsx
@@ -9,9 +9,9 @@ import { getMembers, getMemberProperty } from "../../data/team";
 import { GetStaticProps, GetStaticPaths } from "next";
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const orgs = await getMemberProperty("org");
+  const orgs = await getMemberProperty("orgs");
   return {
-    paths: orgs.map((org) => ({
+    paths: orgs.flat().map((org) => ({
       params: {
         org: normalizeParam(org),
       },
@@ -39,15 +39,20 @@ const Organization: FC<ServerProps> = (props) => {
     return <Error statusCode={500} />;
   }
 
-  const org = router.query.org;
+  const org = Array.isArray(router.query.org)
+    ? router.query.org[0]
+    : router.query.org;
   let formattedOrg = "";
 
+  if (!org) {
+    return <Error statusCode={404} />;
+  }
+
   const data = props.data.filter((member) => {
-    if (member.org && normalizeParam(member.org) === org) {
-      formattedOrg = member.org;
-      return true;
-    }
-    return false;
+    const possibleOrg = member.orgs.find((t) => normalizeParam(t) === org);
+    if (!possibleOrg) return false;
+    formattedOrg = possibleOrg;
+    return true;
   });
 
   return (

--- a/src/pages/subteam/[subteam].tsx
+++ b/src/pages/subteam/[subteam].tsx
@@ -39,11 +39,12 @@ const Subteam: FC<ServerProps> = (props) => {
   let formattedSubteam = "";
 
   const data = props.data.filter((member) => {
-    if (member.subteam && normalizeParam(member.subteam) === subteam) {
-      formattedSubteam = member.subteam;
-      return true;
-    }
-    return false;
+    const possibleSubteam = member.subteams.find(
+      (t) => normalizeParam(t) === subteam
+    );
+    if (!possibleSubteam) return false;
+    formattedSubteam = possibleSubteam;
+    return true;
   });
 
   return (

--- a/src/pages/team/[team].tsx
+++ b/src/pages/team/[team].tsx
@@ -39,11 +39,10 @@ const Team: FC<ServerProps> = (props) => {
   let formattedTeam = "";
 
   const data = props.data.filter((member) => {
-    if (member.team && normalizeParam(member.team) === team) {
-      formattedTeam = member.team;
-      return true;
-    }
-    return false;
+    const possibleTeam = member.teams.find((t) => normalizeParam(t) === team);
+    if (!possibleTeam) return false;
+    formattedTeam = possibleTeam;
+    return true;
   });
 
   return (


### PR DESCRIPTION
Previously we'd have duplicated rows in the gsheet when someone had multiple orgs/teams/etc. Given that it's not exactly a 1-to-1 relationship, I enabled adding multiple orgs/teams/etc for a single individual by separating those entries by a `;`.