### PR TITLE
Trigger sync via http instead of yarn command

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -148,7 +148,12 @@ spec:
           containers:
             - name: team-data-sync-cron
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/team:production
-              args: ["yarn", "prime-cache"]
+              args:
+                [
+                  "wget",
+                  "-qO-",
+                  "http://team-web-internal.default.svc.cluster.local:3000/api/sync",
+                ]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:


### PR DESCRIPTION
Given that team nav syncs to an ephemeral database that's localized to its pod the previous cron invocation that I was using wouldn't work because it was running the `prime-cache` command _in a separate container_. There would potentially be some workaround by having a shared volume, but in talking to @izakp it sounded like that wasn't as straight forward as it seemed. Given that the running pod has a sync command that can be triggered via http, I just moved the cron over to call the service from that pod directly to refresh the data. 