### PR TITLE
Ensure orphaned members are correctly formatted when deleting

### DIFF
--- a/src/pages/api/sync.ts
+++ b/src/pages/api/sync.ts
@@ -117,7 +117,7 @@ export async function sync() {
   );
   if (orphanedMembers.length > 0) {
     await prisma.member.deleteMany({
-      where: { OR: orphanedMembers },
+      where: { OR: orphanedMembers.map((slug) => ({ slug })) },
     });
   }
 


### PR DESCRIPTION
@joeyAghion dropped by #people-tech-wg to let us know the sync job was 500ing. 

The logs in paper trail were pretty unhelpful so I hit the production sync url (`/api/sync`) to see what it was doing. 

I got this error:

```
Unable to match input value to any allowed input type for the field. Parse errors: [Query parsing/validation error at `Mutation.deleteManyMember.where.MemberWhereInput.OR`: Value types mismatch.
```

So the `OR` clause of a `MemberWhereInput` inside a `member.deleteMany` clause was being called. Looking through the instances of `OR:` I noticed the `orphanedMembers` parameter was a `string[]` if you command click on the `deleteMany` clause there you'll see the types specify an object _or_ any array of objects. This string array mapped over to some slugs, so I updated that to an array of objects with a key of `slug` and a value mapped from `orphanedMembers`. 