### PR TITLE
fix: oauth ingress should have /oauth2 as path.

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -141,7 +141,7 @@ spec:
     - host: team-staging.artsy.net
       http:
         paths:
-          - path: /
+          - path: /oauth2
             pathType: Prefix
             backend:
               serviceName: team-web-internal


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1606848657437400