### PR TITLE
Restrict traffic to firewall and internal IPs (PLATFORM-3103)

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -118,6 +118,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-url: "http://team-web-internal.default.svc.cluster.local:3000/api/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://api.artsy.net/oauth2/authorize?response_type=code&client_id={{ PRODUCTION_APP_ID }}&redirect_uri=https://$host/oauth2/callback?rd=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
 spec:
   ingressClassName: nginx
   rules:
@@ -135,6 +136,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: team-oauth
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
 spec:
   ingressClassName: nginx
   rules:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -118,6 +118,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-url: "http://team-web-internal.default.svc.cluster.local:3000/api/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://stagingapi.artsy.net/oauth2/authorize?response_type=code&client_id={{ STAGING_APP_ID }}&redirect_uri=https://$host/oauth2/callback?rd=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
 spec:
   ingressClassName: nginx
   rules:
@@ -135,6 +136,8 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: team-oauth
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
We thought it would be wise to enable firewall protection on more internal apps, including this one. However, this app has a special authentication set-up so I wasn't 100% sure how our usual pattern should be applied to it. I _think_ it's OK for both the 
`team-external-auth` and `team-oauth` ingress definitions to restrict source traffic, so that's what's in this PR.

I've already enabled proxying for both staging and production names. A `hokusai staging update --dry-run --skip-checks` also succeeded. I'll confirm that authentication works as usual once in staging.

https://artsyproduct.atlassian.net/browse/PLATFORM-3103