### PR TITLE
feat: protect cronjob from eviction by cluster-autoscaler, and misc.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -31,9 +31,15 @@ spec:
         - name: team-web
           env:
             - name: PORT
-              value: "3000"
+              value: "8080"
             - name: NODE_ENV
               value: production
+            - name: DATADOG_TRACE_AGENT_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=512"
           envFrom:
             - configMapRef:
                 name: team-environment
@@ -41,13 +47,13 @@ spec:
           imagePullPolicy: Always
           ports:
             - name: team-http
-              containerPort: 3000
+              containerPort: 8080
           resources:
             requests:
-              cpu: 200m
-              memory: 256Mi
-            limits:
+              cpu: 100m
               memory: 512Mi
+            limits:
+              memory: 1Gi
           readinessProbe:
             httpGet:
               port: team-http
@@ -58,11 +64,11 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 10"]
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -85,7 +91,7 @@ spec:
     kind: Deployment
     name: team-web
   minReplicas: 1
-  maxReplicas: 2
+  maxReplicas: 3
   targetCPUUtilizationPercentage: 70
 
 ---
@@ -100,10 +106,10 @@ metadata:
   namespace: default
 spec:
   ports:
-    - port: 3000
+    - port: 8080
       protocol: TCP
       name: http
-      targetPort: 3000
+      targetPort: team-http
   selector:
     app: team
     layer: application
@@ -116,7 +122,7 @@ kind: Ingress
 metadata:
   name: team-external-auth
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "http://team-web-internal.default.svc.cluster.local:3000/api/auth"
+    nginx.ingress.kubernetes.io/auth-url: "http://team-web-internal.default.svc.cluster.local:8080/api/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://api.artsy.net/oauth2/authorize?response_type=code&client_id={{ PRODUCTION_APP_ID }}&redirect_uri=https://$host/oauth2/callback?rd=$escaped_request_uri"
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
 spec:
@@ -129,7 +135,7 @@ spec:
             pathType: Prefix
             backend:
               serviceName: team-web-internal
-              servicePort: 3000
+              servicePort: http
 
 ---
 apiVersion: networking.k8s.io/v1beta1
@@ -148,9 +154,9 @@ spec:
             pathType: Prefix
             backend:
               serviceName: team-web-internal
-              servicePort: 3000
+              servicePort: http
 ---
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: team-data-sync-cron
@@ -159,7 +165,11 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: team-data-sync-cron
@@ -168,7 +178,7 @@ spec:
                 [
                   "wget",
                   "-qO-",
-                  "http://team-web-internal.default.svc.cluster.local:3000/api/sync",
+                  "http://team-web-internal.default.svc.cluster.local:8080/api/sync",
                 ]
               imagePullPolicy: Always
               envFrom:
@@ -177,10 +187,9 @@ spec:
           restartPolicy: Never
           affinity:
             nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 1
-                  preference:
-                    matchExpressions:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
                       - key: tier
                         operator: In
                         values:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -31,7 +31,7 @@ spec:
         - name: team-web
           env:
             - name: PORT
-              value: "3000"
+              value: "8080"
             - name: NODE_ENV
               value: production
             - name: DATADOG_TRACE_AGENT_HOSTNAME
@@ -47,7 +47,7 @@ spec:
           imagePullPolicy: Always
           ports:
             - name: team-http
-              containerPort: 3000
+              containerPort: 8080
           resources:
             requests:
               cpu: 100m
@@ -106,7 +106,7 @@ metadata:
   namespace: default
 spec:
   ports:
-    - port: 3000
+    - port: 8080
       protocol: TCP
       name: http
       targetPort: team-http
@@ -122,7 +122,7 @@ kind: Ingress
 metadata:
   name: team-external-auth
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "http://team-web-internal.default.svc.cluster.local:3000/api/auth"
+    nginx.ingress.kubernetes.io/auth-url: "http://team-web-internal.default.svc.cluster.local:8080/api/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://stagingapi.artsy.net/oauth2/authorize?response_type=code&client_id={{ STAGING_APP_ID }}&redirect_uri=https://$host/oauth2/callback?rd=$escaped_request_uri"
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
 spec:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -34,6 +34,12 @@ spec:
               value: "3000"
             - name: NODE_ENV
               value: production
+            - name: DATADOG_TRACE_AGENT_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: NODE_OPTIONS
+              value: "--max_old_space_size=256"
           envFrom:
             - configMapRef:
                 name: team-environment
@@ -44,7 +50,7 @@ spec:
               containerPort: 3000
           resources:
             requests:
-              cpu: 200m
+              cpu: 100m
               memory: 256Mi
             limits:
               memory: 512Mi
@@ -58,11 +64,11 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 10"]
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -103,7 +109,7 @@ spec:
     - port: 3000
       protocol: TCP
       name: http
-      targetPort: 3000
+      targetPort: team-http
   selector:
     app: team
     layer: application
@@ -129,7 +135,7 @@ spec:
             pathType: Prefix
             backend:
               serviceName: team-web-internal
-              servicePort: 3000
+              servicePort: http
 
 ---
 apiVersion: networking.k8s.io/v1beta1
@@ -148,5 +154,5 @@ spec:
             pathType: Prefix
             backend:
               serviceName: team-web-internal
-              servicePort: 3000
+              servicePort: http
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "prime-cache": "ts-node --dir ./scripts prime-cache.ts",
     "preprime-cache": "yarn create-db",
     "create-db": "prisma db push --preview-feature",
-    "start": "next start",
+    "start": "node scripts/start",
     "predev": "yarn write-creds",
     "dev": "next dev",
     "prebuild": "yarn write-creds && yarn prime-cache",

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,2 @@
+const cli = require('next/dist/cli/next-start')
+cli.nextStart(['-p', process.env.PORT || 3000])


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3197

- Set [safe-to-evict](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node) to false for crons so they cannot be evicted by cluster-autoscaler.
- Set [backoffLimit](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) for crons to reduce retries.
- Adjust resources to reflect usage.
- Generally, true up with hokusai [template](https://github.com/artsy/artsy-hokusai-templates/tree/master/rails-puma/hokusai).