### PR TITLE
fix: preStop still required.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -64,6 +64,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -64,6 +64,10 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 5"]
       dnsPolicy: ClusterFirst
       dnsConfig:
         options:


### PR DESCRIPTION
per https://github.com/artsy/artsy-hokusai-templates/pull/32