### PR TITLE
fix: only try to upload Sharp supported image types

### DIFF
--- a/src/data/image.ts
+++ b/src/data/image.ts
@@ -140,10 +140,21 @@ export async function uploadUserImage(
   );
 
   const contentType = file.headers["content-type"];
-  const extension =
+  const allowedImageTypes = [
+    "JPEG",
+    "PNG",
+    "WebP",
+    "GIF",
+    "SVG",
+    "TIFF",
+  ].map((e) => e.toLowerCase());
+
+  const extension: string | false =
     contentType.includes("image") && contentType.split("image/")[1];
 
   if (!extension) throw new Error(`No valid extension for ${imageUrl.href}`);
+  if (!allowedImageTypes.includes(extension.toLowerCase()))
+    throw new Error(`Invalid image format: ${imageUrl.href}`);
 
   return new Promise((resolve, reject) => {
     file.data.pipe(normalizer).pipe(

--- a/src/pages/api/sync.ts
+++ b/src/pages/api/sync.ts
@@ -146,9 +146,9 @@ export async function sync() {
         uploadUserImage(memberSlug, new URL(headshot))
       );
       if (imageUploadError || !headshotURL) {
-        log.error(`Failed to upload image for ${memberSlug}`, {
-          imageUploadError,
-        });
+        log.error(
+          `Failed to upload image for ${memberSlug}: ${imageUploadError}`
+        );
         headshot = "";
       } else {
         headshot = headshotURL;


### PR DESCRIPTION
After changing images in the Google spreadsheet, we were getting a complete failure of image syncing. This PR makes us a bit more defensive by skipping any images that are not of a type supported by Sharp, which we use for image processing.