### PR TITLE
first day is not an artsyversary

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preprime-cache": "yarn create-db",
     "create-db": "prisma db push --preview-feature",
     "start": "node scripts/start",
-    "predev": "yarn write-creds",
+    "predev": "yarn write-creds; yarn prime-cache",
     "dev": "next dev",
     "prebuild": "yarn write-creds && yarn prime-cache",
     "build": "next build",

--- a/src/pages/member/[member].tsx
+++ b/src/pages/member/[member].tsx
@@ -140,7 +140,7 @@ const Member: FC<MemberProps> = ({ member }) => {
         <Area.Heading>
           <Flex alignItems="center" justifyContent="space-between">
             <H1>{member.name}</H1>
-            {member.startDate && isWeekOf(new Date(member.startDate)) && (
+            {member.startDate && isWeekOf(new Date(member.startDate)) ? (
               <>
                 <Flex ml={4}>
                   <AwardIcon />
@@ -150,7 +150,7 @@ const Member: FC<MemberProps> = ({ member }) => {
                   </Serif>
                 </Flex>
               </>
-            )}
+            ) : null}
           </Flex>
 
           <Separator mb={2} />

--- a/src/pages/member/[member].tsx
+++ b/src/pages/member/[member].tsx
@@ -21,6 +21,7 @@ import { prisma } from "data/prisma";
 import { getSidebarData } from "data/sidebar";
 import { UnWrapPromise } from "utils/type-helpers";
 import { Image } from "components/Image";
+import { differenceInCalendarDays } from "date-fns";
 
 export const getStaticPaths: GetStaticPaths<{ member: string }> = async () => {
   const members = await prisma.member.findMany({
@@ -145,7 +146,10 @@ const Member: FC<MemberProps> = ({ member }) => {
                 <Flex ml={4}>
                   <AwardIcon />
                   <Serif size="4">
-                    Artsyversary{" "}
+			              {differenceInCalendarDays(new Date(member.startDate), Date.now()) > -365
+			                ? "First day"
+			                : "Artsyversary"
+				            }{" "}
                     {relativeDaysTillAnniversary(new Date(member.startDate))}
                   </Serif>
                 </Flex>


### PR DESCRIPTION
Just a quick PR, I saw this earlier today:
<img width="1326" alt="Screenshot 2021-05-04 at 11 36 02" src="https://user-images.githubusercontent.com/100233/117060245-9d036d80-ad18-11eb-835d-43614468d9e8.png">
Didn't make sense to me, so I fixed it.
Now it's:
<img width="249" alt="Screenshot 2021-05-04 at 20 35 18" src="https://user-images.githubusercontent.com/100233/117060305-abea2000-ad18-11eb-9532-20c275b7966b.png">

Also added the prime-cache command in predev after justin's suggestion.