### PR TITLE
style: fix sidebar link line height

### DIFF
--- a/src/components/Sidebar/LinkSection.tsx
+++ b/src/components/Sidebar/LinkSection.tsx
@@ -1,5 +1,5 @@
 import RouteLink from "next/link";
-import { Flex, Sans, Serif, Link, color } from "@artsy/palette";
+import { Flex, Box, Sans, Serif, Link, color } from "@artsy/palette";
 import { External } from "react-bytesize-icons";
 import { useRouter } from "next/router";
 
@@ -17,7 +17,7 @@ interface LinkSectionProps {
 export const LinkSection = ({ title, links }: LinkSectionProps) => {
   const router = useRouter();
   return (
-    <Flex flexDirection="column" mb={3}>
+    <Box mb={3}>
       <Sans size="3t" weight="medium">
         {title}
       </Sans>
@@ -54,6 +54,6 @@ export const LinkSection = ({ title, links }: LinkSectionProps) => {
           </Flex>
         );
       })}
-    </Flex>
+    </Box>
   );
 };


### PR DESCRIPTION
@zephraph and I paired on this lil UI fix for the sidebar links in Safari

<img width="886" alt="Screen Shot 2021-05-19 at 1 22 39 PM" src="https://user-images.githubusercontent.com/140521/118856842-5f205080-b8a5-11eb-9565-c08a9ee723fc.png">
